### PR TITLE
Call template with nice fetch method

### DIFF
--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -65,7 +65,7 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
     {
         $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
 
-        return $this->display(__FILE__, $this->name.'.tpl');
+        return $this->fetch('module:'.$this->name.'/'.$this->name.'.tpl');
     }
 
     public function getWidgetVariables($hookName = null, array $configuration = [])


### PR DESCRIPTION
`$this->display()` should not be used anymore!

Have a look at this: https://github.com/PrestaShop/PrestaShop/pull/6491
