### PR TITLE
Keep the id of the account links

### DIFF
--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -105,7 +105,8 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
             ];
         }
 
-        sort($my_account_urls);
+        // Sort Account links base in his title, keeping the keys
+        asort($my_account_urls);
 
         return [
             'my_account_urls' => $my_account_urls,


### PR DESCRIPTION
Right now, after call `sort` the links get ordered by in his title name (depends of the language) but the key is overridden by the new order.

Using `asort` we order the list but keeping the keys.

In that way in the template (Smarty) we could filter pages using the id and keeping the same behaviour in all the languages. 
