### PR TITLE
Fix call to undefined function

### DIFF
--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -62,8 +62,7 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
 
     public function uninstall()
     {
-        return (parent::uninstall()
-            && $this->removeMyAccountBlockHook());
+        return parent::uninstall();
     }
 
     public function hookActionModuleUnRegisterHookAfter($params)


### PR DESCRIPTION
Fix https://github.com/PrestaShop/PrestaShop/issues/12553

The function removeMyAccountBlockHook() does not exist in all prestashop codebase or in this module.

This line may be inherited from previous versions or beta versions.

Dev branch are outdated.