### PR TITLE
Remove call to undefined method in uninstall

### DIFF
--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -60,12 +60,6 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
         ;
     }
 
-    public function uninstall()
-    {
-        return (parent::uninstall()
-            && $this->removeMyAccountBlockHook());
-    }
-
     public function hookActionModuleUnRegisterHookAfter($params)
     {
         if ('displayMyAccountBlock' === $params['hook_name']) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Function removeMyAccountBlockHook() is missing in class, therefore calling uninstall() causes an error. Hooks get removed anyway by parent::uninstall() so we can remove the override for uninstall() altogether.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Deinstall ps_customeraccounts
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
