### PR TITLE
Solve wording caching if multiple/no addresses

### DIFF
--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -88,7 +88,7 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
     {
         $tpl_key = 'ps_customeraccountlinks';
         if ($this->context->smarty->tpl_vars['customer']->value['addresses']) {
-            $tpl_key .= "_multiple";
+            $tpl_key .= '_multiple';
         }
         if (!$this->isCached($this->templateFile, $this->getCacheId($tpl_key))) {
             $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));

--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -90,7 +90,7 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
         if(Customer::getAddressesTotalById($this->context->customer->id)){
             $tpl_key.="_multiple";
         }
-        if (!$this->isCached($this->templateFile, $this->getCacheId($tpl_key))) {
+        if($this->context->smarty->tpl_vars['customer']->value['addresses']){
             $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
         }
 

--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -87,10 +87,10 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
     public function renderWidget($hookName = null, array $configuration = [])
     {
         $tpl_key = 'ps_customeraccountlinks';
-        if(Customer::getAddressesTotalById($this->context->customer->id)){
+        if($this->context->smarty->tpl_vars['customer']->value['addresses']){
             $tpl_key.="_multiple";
         }
-        if($this->context->smarty->tpl_vars['customer']->value['addresses']){
+        if (!$this->isCached($this->templateFile, $this->getCacheId($tpl_key))) {
             $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
         }
 

--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -86,11 +86,15 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
 
     public function renderWidget($hookName = null, array $configuration = [])
     {
-        if (!$this->isCached($this->templateFile, $this->getCacheId('ps_customeraccountlinks'))) {
+        $tpl_key = 'ps_customeraccountlinks';
+        if(Customer::getAddressesTotalById($this->context->customer->id)){
+            $tpl_key.="_multiple";
+        }
+        if (!$this->isCached($this->templateFile, $this->getCacheId($tpl_key))) {
             $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
         }
 
-        return $this->fetch($this->templateFile, $this->getCacheId('ps_customeraccountlinks'));
+        return $this->fetch($this->templateFile, $this->getCacheId($tpl_key));
     }
 
     public function getWidgetVariables($hookName = null, array $configuration = [])

--- a/ps_customeraccountlinks.php
+++ b/ps_customeraccountlinks.php
@@ -87,8 +87,8 @@ class Ps_Customeraccountlinks extends Module implements WidgetInterface
     public function renderWidget($hookName = null, array $configuration = [])
     {
         $tpl_key = 'ps_customeraccountlinks';
-        if($this->context->smarty->tpl_vars['customer']->value['addresses']){
-            $tpl_key.="_multiple";
+        if ($this->context->smarty->tpl_vars['customer']->value['addresses']) {
+            $tpl_key .= "_multiple";
         }
         if (!$this->isCached($this->templateFile, $this->getCacheId($tpl_key))) {
             $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixes wording problem switching from singular to plural on addresses by clearing cache on addresses updating.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/28983
| How to test?  | Use the test protocol in the solved issue (add and remove addresses)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
